### PR TITLE
store assimpInclude variable in CMake cache

### DIFF
--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -2,5 +2,6 @@ add_subdirectory(pugixml)
 set(ASSIMP_BUILD_TESTS false)
 set(ASSIMP_BUILD_STATIC_LIB true)
 set(ASSIMP_BUILD_ASSIMP_TOOLS false)
-set(assimpInclude ${CMAKE_CURRENT_LIST_DIR}/assimp/include)
+set(assimpInclude ${CMAKE_CURRENT_LIST_DIR}/assimp/include
+    CACHE INTERNAL "assimp include directory")
 add_subdirectory(assimp)


### PR DESCRIPTION
The header directory was not in scope for kriti so it was not included.
